### PR TITLE
Implement CNI Del Operation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
 	github.com/spf13/cobra v1.9.1
-	github.com/vishvananda/netlink v1.3.1
 	k8s.io/api v0.34.0
 	k8s.io/apimachinery v0.34.0
 	k8s.io/client-go v0.34.0

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
 github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
-github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=
-github.com/vishvananda/netlink v1.3.1/go.mod h1:ARtKouGSTGchR8aMwmkzC0qiNPrrWO5JS/XMVl45+b4=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
@@ -199,8 +197,6 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.34.0 h1:O/2T7POpk0ZZ7MAzMeWFSg6S5IpWd/RXDlM9hgM3DR4=

--- a/pkg/cni/cni.go
+++ b/pkg/cni/cni.go
@@ -28,7 +28,6 @@ import (
 	"github.com/containernetworking/cni/libcni"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	resourcev1 "k8s.io/api/resource/v1"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/cni-dra-driver/apis/v1alpha1"
 )
 
@@ -168,8 +167,10 @@ func (rntm *Runtime) add(
 	return result, nil
 }
 
-// DetachNetworks detaches all network interfaces associated with a given pod.
-// It is typically called during pod teardown to clean up network resources.
+// DetachNetworks detaches network interfaces from a pod based on the provided ResourceClaim.
+// It processes the ResourceClaim's device allocation status, extracts CNI configuration for each device,
+// and invokes the CNI DEL operation for each relevant device to clean up network resources.
+// If a request fails, an error is returned and the detach operation stops at the failed device.
 func (rntm *Runtime) DetachNetworks(
 	ctx context.Context,
 	podSandBoxID string,
@@ -177,8 +178,92 @@ func (rntm *Runtime) DetachNetworks(
 	podName string,
 	podNamespace string,
 	podNetworkNamespace string,
-) error {
-	klog.FromContext(ctx).Info("Runtime.DetachNetworks", "podSandBoxID", podSandBoxID, "podUID", podUID, "podName", podName, "podNamespace", podNamespace, "podNetworkNamespace", podNetworkNamespace)
+	claim *resourcev1.ResourceClaim,
+) (*resourcev1.ResourceClaim, error) {
+	if claim == nil || claim.Status.Allocation == nil {
+		return claim, nil
+	}
 
+	requestConfig := map[string]*v1alpha1.CNIConfig{}
+	for _, config := range claim.Status.Allocation.Devices.Config {
+		if config.Opaque == nil || config.Opaque.Driver != rntm.DriverName {
+			continue
+		}
+
+		for _, request := range config.Requests {
+			if _, exists := requestConfig[request]; exists {
+				continue // Multiple Config for a single request is not supported.
+			}
+
+			cniConfig := &v1alpha1.CNIConfig{}
+			err := json.Unmarshal(config.Opaque.Parameters.Raw, cniConfig)
+			if err != nil { // Not a CNI Config
+				continue
+			}
+
+			requestConfig[request] = cniConfig
+		}
+	}
+
+	for _, result := range claim.Status.Allocation.Devices.Results {
+		if result.Driver != rntm.DriverName {
+			continue
+		}
+
+		cniConfig, exists := requestConfig[result.Request]
+		if !exists {
+			return claim, fmt.Errorf("failed to find the cni config for request %q in claim %q", result.Request, claim.Name)
+		}
+
+		err := rntm.del(
+			ctx,
+			podSandBoxID,
+			podUID,
+			podName,
+			podNamespace,
+			podNetworkNamespace,
+			cniConfig,
+		)
+		if err != nil {
+			return claim, err
+		}
+
+		removeAllocatedDeviceStatusFromResourceClaimStatus(claim, &result)
+	}
+
+	return claim, nil
+}
+
+func (rntm *Runtime) del(
+	ctx context.Context,
+	podSandBoxID string,
+	podUID string,
+	podName string,
+	podNamespace string,
+	podNetworkNamespace string,
+	cniConfig *v1alpha1.CNIConfig,
+) error {
+	rt := &libcni.RuntimeConf{
+		ContainerID: podSandBoxID,
+		NetNS:       podNetworkNamespace,
+		IfName:      cniConfig.IfName,
+		Args: [][2]string{
+			{"IgnoreUnknown", "true"},
+			{"K8S_POD_NAMESPACE", podNamespace},
+			{"K8S_POD_NAME", podName},
+			{"K8S_POD_INFRA_CONTAINER_ID", podSandBoxID},
+			{"K8S_POD_UID", podUID},
+		},
+	}
+
+	confList, err := libcni.ConfListFromBytes(cniConfig.Config.Raw)
+	if err != nil {
+		return fmt.Errorf("failed to ConfListFromBytes: %v", err)
+	}
+
+	err = rntm.CNIConfig.DelNetworkList(ctx, confList, rt)
+	if err != nil {
+		return fmt.Errorf("failed to DelNetworkList: %v", err)
+	}
 	return nil
 }

--- a/pkg/cni/exec.go
+++ b/pkg/cni/exec.go
@@ -21,10 +21,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
-	"strings"
 	"syscall"
 	"time"
 
@@ -68,7 +68,7 @@ func (e *RawExec) ExecPlugin(ctx context.Context, pluginPath string, stdinData [
 
 		// If the plugin is currently about to be written, then we wait a
 		// second and try it again
-		if strings.Contains(err.Error(), "text file busy") {
+		if errors.Is(err, syscall.ETXTBSY) {
 			time.Sleep(time.Second)
 			continue
 		}

--- a/pkg/cni/status.go
+++ b/pkg/cni/status.go
@@ -19,6 +19,7 @@ package cni
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	cni100 "github.com/containernetworking/cni/pkg/types/100"
@@ -37,6 +38,18 @@ func addAllocatedDeviceStatusToResourceClaimStatus(claim *resourcev1.ResourceCla
 	}
 
 	claim.Status.Devices = append(claim.Status.Devices, allocatedDeviceStatus)
+}
+
+func removeAllocatedDeviceStatusFromResourceClaimStatus(claim *resourcev1.ResourceClaim, deviceRequestAllocationResult *resourcev1.DeviceRequestAllocationResult) {
+	deviceID := structured.MakeDeviceID(deviceRequestAllocationResult.Driver, deviceRequestAllocationResult.Pool, deviceRequestAllocationResult.Device)
+	sharedDeviceID := structured.MakeSharedDeviceID(deviceID, deviceRequestAllocationResult.ShareID)
+
+	for i, device := range claim.Status.Devices {
+		if getDeviceID(device) == sharedDeviceID {
+			claim.Status.Devices = slices.Delete(claim.Status.Devices, i, i)
+			return
+		}
+	}
 }
 
 func getDeviceID(device resourcev1.AllocatedDeviceStatus) structured.SharedDeviceID {

--- a/pkg/nri/nri.go
+++ b/pkg/nri/nri.go
@@ -54,7 +54,8 @@ type CNIRuntime interface {
 		podName string,
 		podNamespace string,
 		podNetworkNamespace string,
-	) error
+		claim *resourcev1.ResourceClaim,
+	) (*resourcev1.ResourceClaim, error)
 }
 
 // UpdateStatus is a function updating the status of the devices for a ResourceClaim.
@@ -99,7 +100,7 @@ func (p *Plugin) StopPodSandbox(ctx context.Context, pod *api.PodSandbox) error 
 		return fmt.Errorf("error getting network namespace for pod '%s' in namespace '%s'", pod.Name, pod.Namespace)
 	}
 
-	err := p.CNI.DetachNetworks(ctx, pod.Id, pod.Uid, pod.Name, pod.Namespace, podNetworkNamespace)
+	err := p.detachNetworks(ctx, pod.Id, pod.Uid, pod.Name, pod.Namespace, podNetworkNamespace)
 	if err != nil {
 		return fmt.Errorf("error CNI.DetachNetworks for pod '%s' (uid: %s) in namespace '%s': %v", pod.Name, pod.Uid, pod.Namespace, err)
 	}
@@ -151,6 +152,40 @@ func (p *Plugin) attachNetworks(
 		}
 	}
 
+	if p.UpdateStatusFunc != nil {
+		for _, claim := range updatedClaims {
+			updateErr := p.UpdateStatusFunc(ctx, claim)
+			if updateErr != nil {
+				err = errors.Join(err, fmt.Errorf("failed to update status: %v", err))
+			}
+		}
+	}
+
+	return err
+}
+
+func (p *Plugin) detachNetworks(
+	ctx context.Context,
+	podSandBoxID string,
+	podUID string,
+	podName string,
+	podNamespace string,
+	podNetworkNamespace string,
+) error {
+	var err error
+	claims := p.PodResourceStore.Get(types.UID(podUID))
+
+	klog.FromContext(ctx).Info("detach networks on pod", "podName", podName, "podUID", podUID)
+	updatedClaims := []*resourcev1.ResourceClaim{}
+	for _, claim := range claims {
+		claim, err = p.CNI.DetachNetworks(ctx, podSandBoxID, podUID, podName, podNamespace, podNetworkNamespace, claim)
+		if err != nil {
+			break
+		}
+		updatedClaims = append(updatedClaims, claim)
+	}
+
+	// Do we need to update the status of the ResourceClaims? the resourceclaim will be deleted if the pod is deleted.
 	if p.UpdateStatusFunc != nil {
 		for _, claim := range updatedClaims {
 			updateErr := p.UpdateStatusFunc(ctx, claim)


### PR DESCRIPTION
- Added DetachNetworks implementation to process ResourceClaim device allocations and invoke CNI DEL operations for network cleanup
- Introduced removeAllocatedDeviceStatusFromResourceClaimStatus to update claim status after device detachment
- Improved error handling by using errors.Is for syscall.ETXTBSY check instead of string matching

As a part of https://github.com/kubernetes-sigs/cni-dra-driver/issues/11, I want to implement the CNI Del logic in this PR. For the Lifecycle improvement part, I'd like to introduce it in another PR for better review.